### PR TITLE
feat: SiteConfig-driven UI controls + in-repo Wix MCP server

### DIFF
--- a/docs/ui-config-with-velo.md
+++ b/docs/ui-config-with-velo.md
@@ -1,0 +1,40 @@
+UI Control via Velo + SiteConfig
+
+Goal
+- Switch visible UI (banner on/off, hero variant A/B, text and image) without changing layout in the editor, by updating Content Manager.
+
+Prereqs
+- Content Manager collection `SiteConfig` with primary key `main` and fields:
+  - `showBanner` (boolean)
+  - `layoutVariant` (text: expected `A` or `B`)
+  - `heroTitle` (text)
+  - `heroImage` (image or text URL)
+- Page elements with IDs (create as needed):
+  - `#promoStrip`, `#heroA`, `#heroB`, `#heroTitleA`, `#heroTitleB`, `#heroImageA`, `#heroImageB`
+
+What’s included
+- `src/public/site-config-controls.js`: Loads `SiteConfig` and applies values.
+- `src/pages/masterPage.js`: Calls `applySiteConfig()` on page ready.
+
+How it works
+- On every page load, `applySiteConfig()` reads `SiteConfig/main` and:
+  - Expands/Collapses `#promoStrip` based on `showBanner`.
+  - Shows `#heroA` or `#heroB` based on `layoutVariant`.
+  - Sets title/image on matching hero elements if present.
+- All operations are safe if elements do not exist.
+
+Updating from MCP
+- Use the included MCP server in `/wix-mcp` from Claude Desktop.
+- Example to switch layout variant to B and show the banner:
+  - tool: `wix_request`
+  - input:
+    {
+      "method": "PATCH",
+      "path": "/content/v4/collections/SiteConfig/items/main",
+      "body": { "data": { "showBanner": true, "layoutVariant": "B" } }
+    }
+
+Notes
+- Ensure `SiteConfig` read permissions allow public read, write restricted to admins.
+- Extend `site-config-controls.js` with additional mappings as needed (IDs and fields).
+

--- a/src/pages/masterPage.js
+++ b/src/pages/masterPage.js
@@ -2,11 +2,14 @@
 // “Hello, World!” Example: https://learn-code.wix.com/en/article/hello-world
 
 import { applyModernStyles, applyResponsiveTypography, enableDarkMode, addKineticAnimation } from 'public/modern-styles-2025.js';
+import { applySiteConfig } from 'public/site-config-controls.js';
 
 $w.onReady(function () {
     // Apply 2025 modern design system
     applyModernStyles();
     applyResponsiveTypography();
+    // Apply content-driven UI toggles (banner, hero variants, etc.)
+    applySiteConfig();
     
     // Enhanced Navigation and User Experience
     initializeNavigation();
@@ -198,6 +201,15 @@ function hideMobileMenu() {
     if (menuContainer && menuContainer.isVisible) {
         menuContainer.hide('slide', { direction: 'top' });
     }
+}
+
+// Safe no-op stubs to avoid runtime errors if not yet implemented
+function initializeModernUI() {
+    // Placeholder for additional modern UI setup
+}
+
+function setupKineticAnimations() {
+    // Placeholder for kinetic animations wiring
 }
 
 function initializeModernUI() {

--- a/src/public/site-config-controls.js
+++ b/src/public/site-config-controls.js
@@ -1,0 +1,77 @@
+// Site-wide UI controls driven by Content Manager collection "SiteConfig".
+// Expected collection (read-only for public): SiteConfig with primary key 'main'
+// Fields (suggested):
+// - showBanner: boolean
+// - layoutVariant: 'A' | 'B'
+// - heroTitle: string
+// - heroImage: string (image URL)
+
+import wixData from 'wix-data';
+
+const CONFIG_COLLECTION = 'SiteConfig';
+const CONFIG_ID = 'main';
+
+export async function applySiteConfig() {
+  const cfg = await loadConfigSafe();
+  if (!cfg) return;
+
+  // Banner visibility toggle (optional element)
+  toggleElementVisibility('#promoStrip', !!cfg.showBanner);
+
+  // Hero variant toggle (expects two sections with these IDs; safely no-op if missing)
+  const variant = cfg.layoutVariant === 'B' ? 'B' : 'A';
+  if (variant === 'A') {
+    showIfExists('#heroA');
+    hideIfExists('#heroB');
+  } else {
+    hideIfExists('#heroA');
+    showIfExists('#heroB');
+  }
+
+  // Text/image bindings for common hero elements (apply to both variants if present)
+  setTextIfExists('#heroTitleA', cfg.heroTitle);
+  setTextIfExists('#heroTitleB', cfg.heroTitle);
+  setImageIfExists('#heroImageA', cfg.heroImage);
+  setImageIfExists('#heroImageB', cfg.heroImage);
+}
+
+async function loadConfigSafe() {
+  try {
+    return await wixData.get(CONFIG_COLLECTION, CONFIG_ID);
+  } catch (e) {
+    console.error('SiteConfig load failed', e);
+    return null;
+  }
+}
+
+function elementOrNull(selector) {
+  try { return $w(selector); } catch { return null; }
+}
+
+function toggleElementVisibility(selector, visible) {
+  const el = elementOrNull(selector);
+  if (!el) return;
+  if (visible) {
+    try { el.expand ? el.expand() : el.show && el.show(); } catch {}
+  } else {
+    try { el.collapse ? el.collapse() : el.hide && el.hide(); } catch {}
+  }
+}
+
+function showIfExists(selector) { toggleElementVisibility(selector, true); }
+function hideIfExists(selector) { toggleElementVisibility(selector, false); }
+
+function setTextIfExists(selector, value) {
+  if (value == null) return;
+  const el = elementOrNull(selector);
+  if (!el) return;
+  try { el.text = String(value); } catch {}
+}
+
+function setImageIfExists(selector, src) {
+  if (!src) return;
+  const el = elementOrNull(selector);
+  if (!el) return;
+  try { el.src = String(src); } catch {}
+}
+

--- a/tools/wix-mcp/.env.example
+++ b/tools/wix-mcp/.env.example
@@ -1,0 +1,3 @@
+WIX_ACCESS_TOKEN=your_access_token_here
+WIX_SITE_ID=your_site_id_here
+

--- a/tools/wix-mcp/README.md
+++ b/tools/wix-mcp/README.md
@@ -1,0 +1,33 @@
+Wix MCP Server (in-repo)
+
+Setup
+- Node 18+
+- Install SDK in this folder:
+  - `npm init -y && npm i @modelcontextprotocol/sdk`
+- Env vars:
+  - `WIX_ACCESS_TOKEN` (required)
+  - `WIX_SITE_ID` (optional)
+
+Claude Desktop config
+{
+  "mcpServers": {
+    "wix": {
+      "command": "node",
+      "args": ["<abs-path>/tools/wix-mcp/server.mjs"],
+      "env": {
+        "WIX_ACCESS_TOKEN": "<token>",
+        "WIX_SITE_ID": "<siteId>"
+      }
+    }
+  }
+}
+
+Tools
+- `wix_request` generic REST
+- `update_site_config` convenience PATCH for `SiteConfig/main`
+- `update_collection_item` generic item PATCH
+
+Examples
+- Update SiteConfig:
+  { "data": { "showBanner": true, "layoutVariant": "B" } }
+

--- a/tools/wix-mcp/package.json
+++ b/tools/wix-mcp/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "wix-mcp-server",
+  "version": "0.1.0",
+  "type": "module",
+  "private": true,
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^0.1.0"
+  }
+}
+

--- a/tools/wix-mcp/server.mjs
+++ b/tools/wix-mcp/server.mjs
@@ -1,0 +1,167 @@
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+
+const server = new Server(
+  { name: "wix-mcp", version: "0.1.0" },
+  { capabilities: { tools: {} } }
+);
+
+const BASE_URL = "https://www.wixapis.com";
+const ACCESS_TOKEN = process.env.WIX_ACCESS_TOKEN;
+const DEFAULT_SITE_ID = process.env.WIX_SITE_ID;
+
+if (!ACCESS_TOKEN) {
+  console.error("WIX_ACCESS_TOKEN is required.");
+  process.exit(1);
+}
+
+server.tool(
+  "wix_request",
+  {
+    description:
+      "Call Wix REST API. Provide method, path (e.g. /site-properties/v4/sites/{siteId}), optional query/body/headers. Adds Authorization automatically.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        method: { type: "string", enum: ["GET", "POST", "PUT", "PATCH", "DELETE"] },
+        path: { type: "string", description: "Path starting with / under wixapis.com" },
+        query: { type: "object", additionalProperties: true },
+        body: { type: "object", additionalProperties: true },
+        headers: { type: "object", additionalProperties: true },
+        siteId: { type: "string", description: "Overrides default WIX_SITE_ID" }
+      },
+      required: ["method", "path"]
+    }
+  },
+  async ({ input }) => {
+    const { method, path, query = {}, body, headers = {}, siteId } = input;
+
+    if (!path.startsWith("/")) {
+      throw new Error("path must start with '/' (relative to wixapis.com)");
+    }
+    const url = new URL(BASE_URL + path);
+    for (const [k, v] of Object.entries(query)) {
+      url.searchParams.set(k, String(v));
+    }
+
+    const finalHeaders = {
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
+      "Content-Type": "application/json",
+      ...headers
+    };
+
+    const effectiveSiteId = siteId || DEFAULT_SITE_ID;
+    if (effectiveSiteId && !("wix-site-id" in headers)) {
+      finalHeaders["wix-site-id"] = effectiveSiteId;
+    }
+
+    const res = await fetch(url, {
+      method,
+      headers: finalHeaders,
+      body: ["POST", "PUT", "PATCH"].includes(method) && body ? JSON.stringify(body) : undefined
+    });
+
+    const text = await res.text();
+    let data;
+    try {
+      data = JSON.parse(text);
+    } catch {
+      data = text;
+    }
+
+    if (!res.ok) {
+      return {
+        content: [
+          { type: "text", text: JSON.stringify({ status: res.status, data }, null, 2) }
+        ],
+        isError: true
+      };
+    }
+
+    return {
+      content: [
+        { type: "text", text: JSON.stringify({ status: res.status, data }, null, 2) }
+      ]
+    };
+  }
+);
+
+// Convenience tool: update_site_config (PATCH)
+server.tool(
+  "update_site_config",
+  {
+    description: "Patch Content Manager SiteConfig/main with provided fields.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        data: { type: "object", additionalProperties: true }
+      },
+      required: ["data"]
+    }
+  },
+  async ({ input }) => {
+    const url = new URL(BASE_URL + "/content/v4/collections/SiteConfig/items/main");
+    const headers = {
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
+      "Content-Type": "application/json"
+    };
+    if (DEFAULT_SITE_ID) headers["wix-site-id"] = DEFAULT_SITE_ID;
+
+    const res = await fetch(url, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ data: input.data })
+    });
+
+    const bodyText = await res.text();
+    let data;
+    try { data = JSON.parse(bodyText); } catch { data = bodyText; }
+    return {
+      content: [{ type: "text", text: JSON.stringify({ status: res.status, data }, null, 2) }],
+      isError: !res.ok
+    };
+  }
+);
+
+// Generic tool: update_collection_item (PATCH)
+server.tool(
+  "update_collection_item",
+  {
+    description: "Patch any Content Manager item by collectionId and itemId.",
+    inputSchema: {
+      type: "object",
+      properties: {
+        collectionId: { type: "string" },
+        itemId: { type: "string" },
+        data: { type: "object", additionalProperties: true }
+      },
+      required: ["collectionId", "itemId", "data"]
+    }
+  },
+  async ({ input }) => {
+    const { collectionId, itemId, data: patch } = input;
+    const url = new URL(BASE_URL + `/content/v4/collections/${encodeURIComponent(collectionId)}/items/${encodeURIComponent(itemId)}`);
+    const headers = {
+      Authorization: `Bearer ${ACCESS_TOKEN}`,
+      "Content-Type": "application/json"
+    };
+    if (DEFAULT_SITE_ID) headers["wix-site-id"] = DEFAULT_SITE_ID;
+
+    const res = await fetch(url, {
+      method: "PATCH",
+      headers,
+      body: JSON.stringify({ data: patch })
+    });
+    const bodyText = await res.text();
+    let data;
+    try { data = JSON.parse(bodyText); } catch { data = bodyText; }
+    return {
+      content: [{ type: "text", text: JSON.stringify({ status: res.status, data }, null, 2) }],
+      isError: !res.ok
+    };
+  }
+);
+
+const transport = new StdioServerTransport();
+server.connect(transport);
+


### PR DESCRIPTION
This PR introduces config-driven UI controls and an in-repo Wix MCP server.

Changes
- Add src/public/site-config-controls.js and wire into src/pages/masterPage.js
- Add docs/ui-config-with-velo.md (how to set up SiteConfig and IDs)
- Add tools/wix-mcp (MCP server, README, package.json, .env.example)
- Add safe stubs for initializeModernUI/setupKineticAnimations in masterPage

Outcome
- Enable external control of banner visibility, hero variant (A/B), hero texts/images via Content Manager
- Allow automation from Claude Desktop via MCP tools (wix_request, update_site_config, update_collection_item)

Notes
- Ensure Content Manager collection 'SiteConfig' exists with id 'main' and fields: showBanner(boolean), layoutVariant(text), heroTitle(text), heroImage(image/url)
- Assign element IDs used in the mapping where applicable.
